### PR TITLE
Add twz_rt_fd_rename to file descriptor ABI

### DIFF
--- a/include/twizzler/rt/fd.h
+++ b/include/twizzler/rt/fd.h
@@ -160,6 +160,9 @@ extern twz_error twz_rt_fd_mkns(const char *name, size_t name_len);
 /// Create a new symlink.
 extern twz_error twz_rt_fd_symlink(const char *name, size_t name_len, const char *target, size_t target_len);
 
+/// Rename a name in the namespace.
+extern twz_error twz_rt_fd_rename(const char *old_name, size_t old_name_len, const char *new_name, size_t new_name_len);
+
 /// Read symlink.
 extern twz_error twz_rt_fd_readlink(const char *name, size_t name_len, char *buf, size_t buf_len, uint64_t *out_buf_len);
 

--- a/rt-abi/src/fd.rs
+++ b/rt-abi/src/fd.rs
@@ -256,6 +256,19 @@ pub fn twz_rt_fd_symlink(name: &str, target: &str) -> Result<()> {
     }
 }
 
+/// Rename a name in the namespace.
+pub fn twz_rt_fd_rename(old_name: &str, new_name: &str) -> Result<()> {
+    unsafe {
+        RawTwzError::new(crate::bindings::twz_rt_fd_rename(
+            old_name.as_ptr().cast(),
+            old_name.len(),
+            new_name.as_ptr().cast(),
+            new_name.len(),
+        ))
+        .result()
+    }
+}
+
 pub fn twz_rt_fd_readlink(name: &str, buf: &mut [u8]) -> Result<usize> {
     let mut len: u64 = 0;
     unsafe {


### PR DESCRIPTION
Adds a rename operation for names in the namespace, following the same pattern as symlink/remove. Takes old and new name/length pairs. Implemented by twizzler-operating-system/twizzler#320