### PR TITLE
fix: bindgen path for headers

### DIFF
--- a/types/build.rs
+++ b/types/build.rs
@@ -33,10 +33,14 @@ fn main() {
         bg.arg("-I").arg(headers);
     }
     if let Some(sysroots) = sysroots {
-        let sysheaders = format!("{}/{}", sysroots, target);
+        let sysheaders = format!("{}/{}/include", sysroots, target);
         bg.arg("-I").arg(sysheaders);
     }
 
-    let _status = bg.status().expect("failed to generate bindings");
+    let status = bg.status().expect("failed to generate bindings");
+    if !status.success() {
+        panic!("failed to generate bindings");
+    }
+   
     println!("cargo::rerun-if-changed=../include");
 }


### PR DESCRIPTION
Before this fix, bindgen would fail to create bindings for `objid`, which would stop Twizzler from bootstrapping on macOS. I fixed the include path for `sysheaders`, as well as ensuring that bindgen completes without erroring.